### PR TITLE
Return 404 when screen does not exist.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ v0.2 (unreleased)
 
 - Match instructions on usage with reality.
 
+- Return 404 instead of incorrect JS file when screen does not exist.
+
+- Only allow alphanumeric-dash-underscore in screens slug URL.
+
 
 v0.1.2 (2016-02-16)
 -------------------

--- a/lizard_apps/urls.py
+++ b/lizard_apps/urls.py
@@ -11,5 +11,5 @@ from django.conf.urls import url
 from lizard_apps import views
 
 urlpatterns = [
-    url(r'^screens/(?P<slug>.+)\.js', views.AppScreenView.as_view()),
+    url(r'^screens/(?P<slug>[\w-]+)\.js', views.AppScreenView.as_view()),
 ]

--- a/lizard_apps/views.py
+++ b/lizard_apps/views.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from django.views.generic import TemplateView
+from django.shortcuts import get_object_or_404
 
 from lizard_apps.models import Screen
 
@@ -16,4 +17,4 @@ class AppScreenView(TemplateView):
     template_name = "lizard_apps/script.js"
 
     def screen(self):
-        return Screen.objects.get(slug=self.kwargs['slug'])
+        return get_object_or_404(Screen, slug=self.kwargs['slug'])


### PR DESCRIPTION
And only allow alphanumeric-dash-underscore in screens slug URL.
