### PR TITLE
Update style.css

### DIFF
--- a/lizard_apps/static/lizard_apps/style.css
+++ b/lizard_apps/static/lizard_apps/style.css
@@ -114,9 +114,12 @@
   border-radius: 10px;
   max-width: 100%;
   max-height: 100%;
+  width: 70px;
+  
 }
 
-/* hide the title if necessary*/
 .lizard-apps .lizard-apps-icon > a span {
-  display: none;
+  display: block;
+  font-size: 12px;
+  color: #7F8C8D;
 }


### PR DESCRIPTION
Reintroduces the title under app icons because we're getting more icons now and it's not always obvious from the icon itself.
Also shrinking the app icon to 70px.

![screen shot 2016-10-13 at 15 58 20](https://cloud.githubusercontent.com/assets/7193/19351919/eb3e8a42-915d-11e6-8e2f-3f69c2a1eedb.jpg)
